### PR TITLE
chore(dev): add Laravel Sail for local dev, keep fast CI (no Sail); wire Redis (cache/session/queue) for future use

### DIFF
--- a/.github/workflows/backend-laravel.yml
+++ b/.github/workflows/backend-laravel.yml
@@ -26,6 +26,12 @@ jobs:
         options: >-
           --health-cmd="pg_isready -U postgres"
           --health-interval=10s --health-timeout=5s --health-retries=10
+      # redis:
+      #   image: redis:7
+      #   ports: ["6379:6379"]
+      #   options: >-
+      #     --health-cmd="redis-cli ping"
+      #     --health-interval=10s --health-timeout=5s --health-retries=10
 
     env:
       APP_ENV: testing
@@ -60,4 +66,4 @@ jobs:
 
       - name: Run tests
         working-directory: backend-laravel
-        run: php artisan test --parallel
+        run: php artisan test --parallel --exclude-group=redis

--- a/README.md
+++ b/README.md
@@ -17,9 +17,12 @@
 cd backend-laravel
 cp .env.example .env
 ./vendor/bin/sail up -d
-php artisan migrate
-php artisan test
+./vendor/bin/sail artisan migrate:fresh --seed
+./vendor/bin/sail artisan test
 ```
+
+CI では Sail を使わず、ネイティブ PHP + Postgres サービスで高速にテストしています。
+Redis を無効化したい場合は `.env` で `CACHE_STORE=array` `SESSION_DRIVER=array` `QUEUE_CONNECTION=sync` に切り替えてください。
 
 ### Frontend
 ```bash

--- a/backend-laravel/.env.example
+++ b/backend-laravel/.env.example
@@ -7,16 +7,27 @@ APP_URL=http://localhost
 LOG_CHANNEL=stack
 
 DB_CONNECTION=pgsql
-DB_HOST=postgres
+DB_HOST=pgsql
 DB_PORT=5432
 DB_DATABASE=app
-DB_USERNAME=postgres
-DB_PASSWORD=postgres
+DB_USERNAME=sail
+DB_PASSWORD=password
+
+# Redis: ローカルは Sail の redis に合わせる
 
 CACHE_STORE=redis
+SESSION_DRIVER=redis
 QUEUE_CONNECTION=redis
-SESSION_DRIVER=cookie
+REDIS_CLIENT=phpredis
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_PASSWORD=null
 SESSION_LIFETIME=120
+
+# CI や Redis 無効化時は以下で上書き
+# CACHE_STORE=array
+# SESSION_DRIVER=array
+# QUEUE_CONNECTION=sync
 
 SANCTUM_STATEFUL_DOMAINS=localhost,127.0.0.1,localhost:3000
 FRONTEND_URL=http://localhost:3000

--- a/backend-laravel/composer.json
+++ b/backend-laravel/composer.json
@@ -15,7 +15,7 @@
         "fakerphp/faker": "^1.23",
         "laravel/pail": "^1.2.2",
         "laravel/pint": "^1.13",
-        "laravel/sail": "^1.41",
+        "laravel/sail": "^1.44",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
         "pestphp/pest": "^3.8",

--- a/backend-laravel/composer.lock
+++ b/backend-laravel/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03e7275a1165344908728a4a06299409",
+    "content-hash": "d1007d27f83afc4d9e9cf93427206c81",
     "packages": [
         {
             "name": "brick/math",

--- a/backend-laravel/config/cache.php
+++ b/backend-laravel/config/cache.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'default' => env('CACHE_STORE', 'database'),
+    'default' => env('CACHE_STORE', 'file'),
 
     /*
     |--------------------------------------------------------------------------

--- a/backend-laravel/config/database.php
+++ b/backend-laravel/config/database.php
@@ -1,7 +1,5 @@
 <?php
 
-use Illuminate\Support\Str;
-
 return [
 
     /*
@@ -142,33 +140,25 @@ return [
     */
 
     'redis' => [
-
         'client' => env('REDIS_CLIENT', 'phpredis'),
-
-        'options' => [
-            'cluster' => env('REDIS_CLUSTER', 'redis'),
-            'prefix' => env('REDIS_PREFIX', Str::slug((string) env('APP_NAME', 'laravel')).'-database-'),
-            'persistent' => env('REDIS_PERSISTENT', false),
-        ],
-
         'default' => [
-            'url' => env('REDIS_URL'),
             'host' => env('REDIS_HOST', '127.0.0.1'),
-            'username' => env('REDIS_USERNAME'),
             'password' => env('REDIS_PASSWORD'),
-            'port' => env('REDIS_PORT', '6379'),
-            'database' => env('REDIS_DB', '0'),
+            'port' => (int) env('REDIS_PORT', 6379),
+            'database' => (int) env('REDIS_DB', 0),
         ],
-
         'cache' => [
-            'url' => env('REDIS_URL'),
-            'host' => env('REDIS_HOST', '127.0.0.1'),
-            'username' => env('REDIS_USERNAME'),
+            'host' => env('REDIS_HOST_CACHE', env('REDIS_HOST', '127.0.0.1')),
             'password' => env('REDIS_PASSWORD'),
-            'port' => env('REDIS_PORT', '6379'),
-            'database' => env('REDIS_CACHE_DB', '1'),
+            'port' => (int) env('REDIS_PORT', 6379),
+            'database' => (int) env('REDIS_CACHE_DB', 1),
         ],
-
+        'queue' => [
+            'host' => env('REDIS_QUEUE_HOST', env('REDIS_HOST', '127.0.0.1')),
+            'password' => env('REDIS_PASSWORD'),
+            'port' => (int) env('REDIS_QUEUE_PORT', env('REDIS_PORT', 6379)),
+            'database' => (int) env('REDIS_QUEUE_DB', 2),
+        ],
     ],
 
 ];

--- a/backend-laravel/config/queue.php
+++ b/backend-laravel/config/queue.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('QUEUE_CONNECTION', 'database'),
+    'default' => env('QUEUE_CONNECTION', 'sync'),
 
     /*
     |--------------------------------------------------------------------------
@@ -65,11 +65,10 @@ return [
 
         'redis' => [
             'driver' => 'redis',
-            'connection' => env('REDIS_QUEUE_CONNECTION', 'default'),
+            'connection' => 'queue',
             'queue' => env('REDIS_QUEUE', 'default'),
-            'retry_after' => (int) env('REDIS_QUEUE_RETRY_AFTER', 90),
+            'retry_after' => 90,
             'block_for' => null,
-            'after_commit' => false,
         ],
 
     ],

--- a/backend-laravel/docker-compose.yml
+++ b/backend-laravel/docker-compose.yml
@@ -1,11 +1,11 @@
 services:
     laravel.test:
         build:
-            context: './vendor/laravel/sail/runtimes/8.4'
+            context: ./vendor/laravel/sail/runtimes/8.4
             dockerfile: Dockerfile
             args:
                 WWWGROUP: '${WWWGROUP}'
-        image: 'sail-8.4/app'
+        image: sail-8.4/app
         extra_hosts:
             - 'host.docker.internal:host-gateway'
         ports:
@@ -22,34 +22,9 @@ services:
         networks:
             - sail
         depends_on:
-            - postgres
+            - pgsql
             - redis
             - mailpit
-    postgres:
-        image: 'postgres:17'
-        ports:
-            - '${FORWARD_DB_PORT:-5432}:5432'
-        environment:
-            PGPASSWORD: '${DB_PASSWORD:-secret}'
-            POSTGRES_DB: '${DB_DATABASE}'
-            POSTGRES_USER: '${DB_USERNAME}'
-            POSTGRES_PASSWORD: '${DB_PASSWORD:-secret}'
-        volumes:
-            - 'sail-postgres:/var/lib/postgresql/data'
-            - './vendor/laravel/sail/database/pgsql/create-testing-database.sql:/docker-entrypoint-initdb.d/10-create-testing-database.sql'
-        networks:
-            - sail
-        healthcheck:
-            test:
-                - CMD
-                - pg_isready
-                - '-q'
-                - '-d'
-                - '${DB_DATABASE}'
-                - '-U'
-                - '${DB_USERNAME}'
-            retries: 3
-            timeout: 5s
     redis:
         image: 'redis:alpine'
         ports:
@@ -72,11 +47,36 @@ services:
             - '${FORWARD_MAILPIT_DASHBOARD_PORT:-8025}:8025'
         networks:
             - sail
+    pgsql:
+        image: 'postgres:17'
+        ports:
+            - '${FORWARD_DB_PORT:-5432}:5432'
+        environment:
+            PGPASSWORD: '${DB_PASSWORD:-secret}'
+            POSTGRES_DB: '${DB_DATABASE}'
+            POSTGRES_USER: '${DB_USERNAME}'
+            POSTGRES_PASSWORD: '${DB_PASSWORD:-secret}'
+        volumes:
+            - 'sail-pgsql:/var/lib/postgresql/data'
+            - './vendor/laravel/sail/database/pgsql/create-testing-database.sql:/docker-entrypoint-initdb.d/10-create-testing-database.sql'
+        networks:
+            - sail
+        healthcheck:
+            test:
+                - CMD
+                - pg_isready
+                - '-q'
+                - '-d'
+                - '${DB_DATABASE}'
+                - '-U'
+                - '${DB_USERNAME}'
+            retries: 3
+            timeout: 5s
 networks:
     sail:
         driver: bridge
 volumes:
-    sail-postgres:
-        driver: local
     sail-redis:
+        driver: local
+    sail-pgsql:
         driver: local

--- a/backend-laravel/sail
+++ b/backend-laravel/sail
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+if [ -f vendor/bin/sail ]; then
+    bash vendor/bin/sail "$@"
+else
+    bash vendor/laravel/sail/bin/sail "$@"
+fi

--- a/backend-laravel/tests/Feature/RedisSmokeTest.php
+++ b/backend-laravel/tests/Feature/RedisSmokeTest.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Redis;
+
+it('interacts with redis', function () {
+    Redis::set('smoke', 'ok');
+    expect(Redis::get('smoke'))->toBe('ok');
+})->group('redis');

--- a/docs/local/Sail.md
+++ b/docs/local/Sail.md
@@ -1,0 +1,25 @@
+# Laravel Sail でのローカル開発
+
+## 起動
+
+```bash
+cd backend-laravel
+cp .env.example .env
+composer install
+./vendor/bin/sail up -d
+```
+
+## マイグレーションとテスト
+
+```bash
+./vendor/bin/sail artisan migrate:fresh --seed
+./vendor/bin/sail artisan test
+```
+
+フロントエンド(Next.js)を同時に起動する場合は、`SANCTUM_STATEFUL_DOMAINS` や `FRONTEND_URL` のポートに注意してください。CORS エラーが出る場合は `.env` を調整します。
+
+## 停止
+
+```bash
+./vendor/bin/sail down
+```

--- a/docs/ops/Redis.md
+++ b/docs/ops/Redis.md
@@ -1,0 +1,28 @@
+# Redis 運用メモ
+
+## 切り替え方
+
+小規模環境では `.env` で以下を設定し、Redis を使わずに動作できます。
+
+```env
+CACHE_STORE=array
+SESSION_DRIVER=array
+QUEUE_CONNECTION=sync
+```
+
+Redis を有効化する場合は、次の値に変更します。
+
+```env
+CACHE_STORE=redis
+SESSION_DRIVER=redis
+QUEUE_CONNECTION=redis
+```
+
+## キャッシュとキューのポリシー
+
+- キャッシュ用途は `LFU/LRU` などの eviction policy を設定し、適宜期限切れを許容します。
+- キュー用途は `noeviction` を推奨し、ジョブ消失を防ぎます。将来は別インスタンスに分離することも検討します。
+
+## 本番での差し替え
+
+本番環境では `REDIS_HOST` などを AWS ElastiCache 等のエンドポイントに差し替えるだけで利用できます。


### PR DESCRIPTION
## Summary
- set up Laravel Sail (pgsql/redis/mailpit) and helper script for local containers
- wire Redis config for cache, session and queues while keeping safe defaults
- keep CI on native PHP/Postgres with env overrides and notes for future Redis
- document Sail usage and Redis ops, update README

## Testing
- `./vendor/bin/sail up -d` *(fails: Docker is not running)*
- `APP_KEY=… APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=database/database.sqlite CACHE_STORE=array SESSION_DRIVER=array QUEUE_CONNECTION=sync php artisan test --exclude-group=redis` *(warnings: missing .env)*

------
https://chatgpt.com/codex/tasks/task_e_689aeb4c45848327ab76e79aa4ba8c23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved local development setup with Sail, adding Redis and Mailpit services.
- Documentation
  - Added guides for using Sail locally and operating Redis.
  - Updated README with Sail commands, CI notes, and steps to disable Redis.
- Chores
  - CI now skips Redis-tagged tests for faster runs.
  - Updated Sail dependency and added a Sail launcher script.
  - Switched docker-compose database service to pgsql.
  - Updated example environment for Redis.
  - Adjusted default cache and queue fallbacks to file and sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->