### PR TITLE
feat(rate-limit): throttle /auth/login and add 429 test

### DIFF
--- a/backend-laravel/app/Providers/RouteServiceProvider.php
+++ b/backend-laravel/app/Providers/RouteServiceProvider.php
@@ -20,5 +20,9 @@ class RouteServiceProvider extends ServiceProvider
             return Limit::perMinute((int) config('api.rate_limit_per_min', 60))
                 ->by(optional($request->user())->id ?: $request->ip());
         });
+
+        RateLimiter::for('login', function (Request $request) {
+            return Limit::perMinute(10)->by($request->ip());
+        });
     }
 }

--- a/backend-laravel/routes/api.php
+++ b/backend-laravel/routes/api.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\ThreadController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/auth/register', [AuthController::class, 'register']);
-Route::post('/auth/login', [AuthController::class, 'login']);
+Route::post('/auth/login', [AuthController::class, 'login'])->middleware('throttle:login');
 Route::post('/auth/logout', [AuthController::class, 'logout'])->middleware('auth:sanctum');
 Route::get('/user', [AuthController::class, 'user'])->middleware('auth:sanctum');
 

--- a/backend-laravel/tests/Feature/AuthRateLimitTest.php
+++ b/backend-laravel/tests/Feature/AuthRateLimitTest.php
@@ -24,4 +24,3 @@ test('login is rate limited', function () {
         'password' => 'invalid',
     ])->assertStatus(429);
 });
-

--- a/backend-laravel/tests/Feature/AuthRateLimitTest.php
+++ b/backend-laravel/tests/Feature/AuthRateLimitTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\postJson;
+
+uses(RefreshDatabase::class);
+
+test('login is rate limited', function () {
+    User::factory()->create([
+        'email' => 'test@example.com',
+    ]);
+
+    for ($i = 0; $i < 10; $i++) {
+        postJson('/api/auth/login', [
+            'email' => 'test@example.com',
+            'password' => 'invalid',
+        ])->assertStatus(401);
+    }
+
+    postJson('/api/auth/login', [
+        'email' => 'test@example.com',
+        'password' => 'invalid',
+    ])->assertStatus(429);
+});
+


### PR DESCRIPTION
## Summary
- throttle `/auth/login` with dedicated `login` rate limiter
- add feature test validating 429 after exceeding 10 failed logins

## Testing
- `composer test` *(fails: Database file at path [testing] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689c297651348327988e4734f3b7bd1b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced rate limiting for login attempts to curb abusive activity. After repeated failed attempts within a short period, additional requests are temporarily blocked with a “Too Many Requests” response. Other API endpoints remain unaffected.

- Tests
  - Added automated tests to validate the login rate-limiting behavior, ensuring correct responses for repeated failed attempts and proper enforcement of the temporary block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->