### PR TITLE
P1: parity fix + negative tests

### DIFF
--- a/backend-laravel/app/Http/Controllers/PostController.php
+++ b/backend-laravel/app/Http/Controllers/PostController.php
@@ -52,6 +52,7 @@ class PostController extends Controller
 
     public function update(PostRequest $request, Thread $thread, Post $post)
     {
+        $this->authorize('update', $post);
         $post->update(['body' => $request->string('body')]);
 
         CacheKeys::bumpPostsVersion($thread->id);
@@ -65,6 +66,7 @@ class PostController extends Controller
 
     public function destroy(Thread $thread, Post $post)
     {
+        $this->authorize('delete', $post);
         $post->delete();
 
         CacheKeys::bumpPostsVersion($thread->id);

--- a/backend-laravel/app/Providers/AuthServiceProvider.php
+++ b/backend-laravel/app/Providers/AuthServiceProvider.php
@@ -3,7 +3,9 @@
 namespace App\Providers;
 
 use App\Models\Post;
+use App\Models\Thread;
 use App\Policies\PostPolicy;
+use App\Policies\ThreadPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 
@@ -16,6 +18,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         Post::class => PostPolicy::class,
+        Thread::class => ThreadPolicy::class,
     ];
 
     /**

--- a/backend-laravel/tests/Feature/AuthNegativeTest.php
+++ b/backend-laravel/tests/Feature/AuthNegativeTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
+
+uses(RefreshDatabase::class);
+
+test('register requires fields', function () {
+    postJson('/api/auth/register', [])->assertStatus(422);
+});
+
+test('logout requires authentication', function () {
+    postJson('/api/auth/logout')->assertStatus(401);
+});
+
+test('fetching user requires authentication', function () {
+    getJson('/api/user')->assertStatus(401);
+});

--- a/backend-laravel/tests/Feature/PostsNegativeTest.php
+++ b/backend-laravel/tests/Feature/PostsNegativeTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\Models\Thread;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\postJson;
+
+uses(RefreshDatabase::class);
+
+test('creating post requires body', function () {
+    $user = User::factory()->create();
+    $thread = Thread::factory()->create();
+    actingAs($user);
+
+    postJson("/api/threads/{$thread->id}/posts", [])->assertStatus(422);
+});

--- a/backend-laravel/tests/Feature/ThreadsNegativeTest.php
+++ b/backend-laravel/tests/Feature/ThreadsNegativeTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
+
+uses(RefreshDatabase::class);
+
+test('fetching non-existent thread returns 404', function () {
+    getJson('/api/threads/999999')->assertStatus(404);
+});
+
+test('creating thread requires title', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    postJson('/api/threads', [])->assertStatus(422);
+});

--- a/docs/agent/api/openapi.yaml
+++ b/docs/agent/api/openapi.yaml
@@ -158,12 +158,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Paginated_Thread'
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
     post:
       operationId: createThread
       summary: Create thread
@@ -176,6 +170,12 @@ paths:
                 $ref: '#/components/schemas/Thread'
         '401':
           description: unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '422':
+          description: validation
           content:
             application/json:
               schema:
@@ -199,12 +199,6 @@ paths:
                 $ref: '#/components/schemas/Thread'
         '404':
           description: not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: unauthorized
           content:
             application/json:
               schema:
@@ -242,6 +236,12 @@ paths:
       summary: Delete (owner only)
       responses:
         '204': { description: ok }
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           description: unauthorized
           content:
@@ -265,12 +265,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Paginated_Post'
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
     post:
       operationId: createPost
       summary: Create post


### PR DESCRIPTION
## Summary
- register `ThreadPolicy`
- enforce Post update/delete authorization
- sync OpenAPI with public GET endpoints and add 422/403 specs
- add negative tests for auth, threads, and posts

## Testing
- `composer test` *(fails: Database file at path [testing] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689c3576cd2c832788478edc65d8bace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Enforced authorization checks on post update and delete actions to prevent unauthorized changes.
- Documentation
  - Updated API spec: added 422 Validation responses for thread/post creation and 403 Forbidden for thread deletion; removed unnecessary 401 responses from select GET/PATCH endpoints.
- Tests
  - Added negative test coverage for authentication requirements, validation errors on thread/post creation, and 404 for missing threads.
- Chores
  - Registered thread authorization policy to align with access control rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->