### PR TITLE
Add update and delete endpoints for posts

### DIFF
--- a/backend-laravel/app/Http/Controllers/PostController.php
+++ b/backend-laravel/app/Http/Controllers/PostController.php
@@ -50,12 +50,12 @@ class PostController extends Controller
         ], 201);
     }
 
-    public function update(PostRequest $request, Thread $thread, Post $post)
+    public function update(PostRequest $request, Post $post)
     {
         $this->authorize('update', $post);
         $post->update(['body' => $request->string('body')]);
 
-        CacheKeys::bumpPostsVersion($thread->id);
+        CacheKeys::bumpPostsVersion($post->thread_id);
 
         return response()->json([
             'data' => new PostResource($post),
@@ -64,12 +64,13 @@ class PostController extends Controller
         ]);
     }
 
-    public function destroy(Thread $thread, Post $post)
+    public function destroy(Post $post)
     {
         $this->authorize('delete', $post);
+        $threadId = $post->thread_id;
         $post->delete();
 
-        CacheKeys::bumpPostsVersion($thread->id);
+        CacheKeys::bumpPostsVersion($threadId);
 
         return response()->noContent();
     }

--- a/backend-laravel/routes/api.php
+++ b/backend-laravel/routes/api.php
@@ -18,3 +18,5 @@ Route::delete('/threads/{thread}', [ThreadController::class, 'destroy'])->middle
 
 Route::get('/threads/{thread}/posts', [PostController::class, 'index']);
 Route::post('/threads/{thread}/posts', [PostController::class, 'store'])->middleware('auth:sanctum');
+Route::put('/posts/{post}', [PostController::class, 'update'])->middleware('auth:sanctum');
+Route::delete('/posts/{post}', [PostController::class, 'destroy'])->middleware('auth:sanctum');

--- a/backend-laravel/tests/Feature/PostTest.php
+++ b/backend-laravel/tests/Feature/PostTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Post;
 use App\Models\Thread;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -27,8 +28,7 @@ test('user can create posts for thread', function () {
 test('user can update a post', function () {
     $user = User::factory()->create();
     $thread = Thread::factory()->for($user)->create();
-    $post = $thread->posts()->create([
-        'user_id' => $user->id,
+    $post = Post::factory()->for($thread)->for($user)->create([
         'body' => 'Hello',
     ]);
     actingAs($user);
@@ -40,8 +40,7 @@ test('user can update a post', function () {
 test('user can delete a post', function () {
     $user = User::factory()->create();
     $thread = Thread::factory()->for($user)->create();
-    $post = $thread->posts()->create([
-        'user_id' => $user->id,
+    $post = Post::factory()->for($thread)->for($user)->create([
         'body' => 'Hello',
     ]);
     actingAs($user);

--- a/backend-laravel/tests/Feature/PostTest.php
+++ b/backend-laravel/tests/Feature/PostTest.php
@@ -5,8 +5,10 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Laravel\deleteJson;
 use function Pest\Laravel\getJson;
 use function Pest\Laravel\postJson;
+use function Pest\Laravel\putJson;
 
 uses(RefreshDatabase::class);
 
@@ -20,4 +22,33 @@ test('user can create posts for thread', function () {
 
     $list = getJson("/api/threads/{$thread->id}/posts");
     $list->assertOk()->assertJsonPath('data.0.body', 'Hello');
+});
+
+test('user can update a post', function () {
+    $user = User::factory()->create();
+    $thread = Thread::factory()->for($user)->create();
+    $post = $thread->posts()->create([
+        'user_id' => $user->id,
+        'body' => 'Hello',
+    ]);
+    actingAs($user);
+
+    $resp = putJson("/api/posts/{$post->id}", ['body' => 'Updated']);
+    $resp->assertOk()->assertJsonPath('data.body', 'Updated');
+});
+
+test('user can delete a post', function () {
+    $user = User::factory()->create();
+    $thread = Thread::factory()->for($user)->create();
+    $post = $thread->posts()->create([
+        'user_id' => $user->id,
+        'body' => 'Hello',
+    ]);
+    actingAs($user);
+
+    deleteJson("/api/posts/{$post->id}")->assertNoContent();
+
+    getJson("/api/threads/{$thread->id}/posts")
+        ->assertOk()
+        ->assertJsonCount(0, 'data');
 });

--- a/docs/agent/api/openapi.yaml
+++ b/docs/agent/api/openapi.yaml
@@ -287,3 +287,54 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /posts/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: integer }
+    put:
+      operationId: updatePost
+      summary: Update post (owner only)
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Post'
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '422':
+          description: validation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      operationId: deletePost
+      summary: Delete post (owner only)
+      responses:
+        '204': { description: ok }
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'


### PR DESCRIPTION
## Summary
- allow posts to be updated and deleted with new routes
- secure post modification via policy-backed controller methods
- document and test post update and deletion APIs

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689c65fd421c8327b4a6a68f54773628

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added authenticated API endpoints to update and delete your own posts (PUT /posts/{id}, DELETE /posts/{id}).
- Documentation
  - API reference updated to document the new post update and deletion endpoints, parameters, and response codes.
- Tests
  - Added automated tests covering successful post updates and deletions, including authorization and validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->