### PR TITLE
Add reactions API with validation and tests

### DIFF
--- a/backend-laravel/app/Http/Controllers/ReactionController.php
+++ b/backend-laravel/app/Http/Controllers/ReactionController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\ReactionResource;
+use App\Models\Post;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class ReactionController extends Controller
+{
+    public function index(Post $post)
+    {
+        $reactions = $post->reactions()->with('user')->get();
+
+        return response()->json([
+            'data' => ReactionResource::collection($reactions),
+            'meta' => (object) [],
+            'error' => null,
+        ]);
+    }
+
+    public function store(Request $request, Post $post)
+    {
+        validator(
+            ['type' => $request->input('type'), 'user_id' => $request->user()->id],
+            [
+                'type' => ['required', 'string'],
+                'user_id' => [
+                    Rule::unique('reactions')->where(fn ($q) => $q->where('post_id', $post->id)),
+                ],
+            ]
+        )->validate();
+
+        $reaction = $post->reactions()->create([
+            'user_id' => $request->user()->id,
+            'type' => $request->string('type'),
+        ])->load('user');
+
+        return response()->json([
+            'data' => new ReactionResource($reaction),
+            'meta' => (object) [],
+            'error' => null,
+        ], 201);
+    }
+
+    public function destroy(Request $request, Post $post)
+    {
+        $reaction = $post->reactions()->where('user_id', $request->user()->id)->first();
+        if ($reaction) {
+            $reaction->delete();
+        }
+
+        return response()->noContent();
+    }
+}

--- a/backend-laravel/app/Http/Resources/ReactionResource.php
+++ b/backend-laravel/app/Http/Resources/ReactionResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\Reaction
+ */
+class ReactionResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'type' => $this->type,
+            'post_id' => $this->post_id,
+            'user' => new UserResource($this->whenLoaded('user')),
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/backend-laravel/database/seeders/DatabaseSeeder.php
+++ b/backend-laravel/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\Post;
+use App\Models\Reaction;
 use App\Models\Thread;
 use App\Models\User;
 use Illuminate\Database\Seeder;
@@ -14,7 +15,7 @@ class DatabaseSeeder extends Seeder
         User::factory()->count(3)->create()->each(function (User $user) {
             Thread::factory()->count(2)
                 ->for($user)
-                ->has(Post::factory()->count(2))
+                ->has(Post::factory()->count(2)->has(Reaction::factory()->count(1)))
                 ->create();
         });
     }

--- a/backend-laravel/routes/api.php
+++ b/backend-laravel/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Auth\AuthController;
 use App\Http\Controllers\PostController;
+use App\Http\Controllers\ReactionController;
 use App\Http\Controllers\ThreadController;
 use Illuminate\Support\Facades\Route;
 
@@ -18,3 +19,7 @@ Route::delete('/threads/{thread}', [ThreadController::class, 'destroy'])->middle
 
 Route::get('/threads/{thread}/posts', [PostController::class, 'index']);
 Route::post('/threads/{thread}/posts', [PostController::class, 'store'])->middleware('auth:sanctum');
+
+Route::get('/posts/{post}/reactions', [ReactionController::class, 'index']);
+Route::post('/posts/{post}/reactions', [ReactionController::class, 'store'])->middleware('auth:sanctum');
+Route::delete('/posts/{post}/reactions', [ReactionController::class, 'destroy'])->middleware('auth:sanctum');

--- a/backend-laravel/tests/Feature/ReactionTest.php
+++ b/backend-laravel/tests/Feature/ReactionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\deleteJson;
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
+
+uses(RefreshDatabase::class);
+
+test('user can react to a post', function () {
+    $user = User::factory()->create();
+    $post = Post::factory()->create();
+
+    actingAs($user);
+
+    $resp = postJson("/api/posts/{$post->id}/reactions", ['type' => 'like']);
+    $resp->assertCreated()->assertJsonPath('data.type', 'like');
+
+    $list = getJson("/api/posts/{$post->id}/reactions");
+    $list->assertOk()->assertJsonCount(1, 'data');
+
+    deleteJson("/api/posts/{$post->id}/reactions")->assertNoContent();
+
+    $list = getJson("/api/posts/{$post->id}/reactions");
+    $list->assertOk()->assertJsonCount(0, 'data');
+});
+
+test('user cannot react twice to same post', function () {
+    $user = User::factory()->create();
+    $post = Post::factory()->create();
+
+    actingAs($user);
+
+    postJson("/api/posts/{$post->id}/reactions", ['type' => 'like'])->assertCreated();
+
+    $resp = postJson("/api/posts/{$post->id}/reactions", ['type' => 'like']);
+    $resp->assertStatus(422);
+});

--- a/docs/agent/api/openapi.yaml
+++ b/docs/agent/api/openapi.yaml
@@ -57,6 +57,21 @@ components:
           type: string
           format: date-time
       required: [id, body, user, thread_id, created_at, updated_at]
+    Reaction:
+      type: object
+      properties:
+        id: { type: integer }
+        type: { type: string }
+        user:
+          $ref: '#/components/schemas/User'
+        post_id: { type: integer }
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required: [id, type, user, post_id, created_at, updated_at]
     Error:
       type: object
       properties:
@@ -83,6 +98,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Post'
+        meta: { type: object }
+      required: [data, meta]
+    Paginated_Reaction:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Reaction'
         meta: { type: object }
       required: [data, meta]
 paths:
@@ -265,16 +289,55 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Paginated_Post'
+      post:
+        operationId: createPost
+        summary: Create post
+        responses:
+          '201':
+            description: created
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Post'
+          '401':
+            description: unauthorized
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Error'
+          '422':
+            description: validation
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Error'
+  /posts/{id}/reactions:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: integer }
+    get:
+      security: []
+      operationId: listReactions
+      summary: List reactions
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Paginated_Reaction'
     post:
-      operationId: createPost
-      summary: Create post
+      operationId: createReaction
+      summary: Create reaction
       responses:
         '201':
           description: created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Post'
+                $ref: '#/components/schemas/Reaction'
         '401':
           description: unauthorized
           content:
@@ -283,6 +346,17 @@ paths:
                 $ref: '#/components/schemas/Error'
         '422':
           description: validation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      operationId: deleteReaction
+      summary: Delete my reaction
+      responses:
+        '204': { description: ok }
+        '401':
+          description: unauthorized
           content:
             application/json:
               schema:

--- a/docs/agent/api/openapi.yaml
+++ b/docs/agent/api/openapi.yaml
@@ -4,8 +4,9 @@ info:
   version: 0.1.0
   license:
     name: MIT
+    url: https://opensource.org/license/mit/
 servers:
-  - url: http://localhost/api
+  - url: https://api.keijiban.com/api
 security:
   - cookieAuth: []
 components:
@@ -182,6 +183,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Paginated_Thread'
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     post:
       operationId: createThread
       summary: Create thread
@@ -289,28 +296,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Paginated_Post'
-      post:
-        operationId: createPost
-        summary: Create post
-        responses:
-          '201':
-            description: created
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/Post'
-          '401':
-            description: unauthorized
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/Error'
-          '422':
-            description: validation
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/Error'
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      operationId: createPost
+      summary: Create post
+      responses:
+        '201':
+          description: created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Post'
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '422':
+          description: validation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /posts/{id}/reactions:
     parameters:
       - name: id
@@ -328,6 +341,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Paginated_Reaction'
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     post:
       operationId: createReaction
       summary: Create reaction


### PR DESCRIPTION
## Summary
- add ReactionController for listing, creating and deleting reactions
- prevent duplicate reactions per user and expose routes
- seed sample reactions and document new endpoints

## Testing
- `composer lint`
- `DB_CONNECTION=sqlite composer test`


------
https://chatgpt.com/codex/tasks/task_e_689c65fedb3c8327a980f3b87e7dece2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - React to posts: list reactions, add your reaction, and remove it. One reaction per user per post. Authentication required to add/remove.

- **Documentation**
  - API docs updated with endpoints and schemas for reactions and paginated reaction responses; also added endpoints for creating/listing posts under threads.

- **Tests**
  - Feature tests cover creating, listing, preventing duplicate, and deleting reactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->