### PR TITLE
Add patch and delete endpoints for posts

### DIFF
--- a/backend-laravel/routes/api.php
+++ b/backend-laravel/routes/api.php
@@ -18,3 +18,5 @@ Route::delete('/threads/{thread}', [ThreadController::class, 'destroy'])->middle
 
 Route::get('/threads/{thread}/posts', [PostController::class, 'index']);
 Route::post('/threads/{thread}/posts', [PostController::class, 'store'])->middleware('auth:sanctum');
+Route::patch('/threads/{thread}/posts/{post}', [PostController::class, 'update'])->middleware('auth:sanctum');
+Route::delete('/threads/{thread}/posts/{post}', [PostController::class, 'destroy'])->middleware('auth:sanctum');

--- a/docs/agent/api/openapi.yaml
+++ b/docs/agent/api/openapi.yaml
@@ -287,3 +287,58 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /threads/{id}/posts/{postId}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: integer }
+      - name: postId
+        in: path
+        required: true
+        schema: { type: integer }
+    patch:
+      operationId: updatePost
+      summary: Update post (owner only)
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Post'
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '422':
+          description: validation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      operationId: deletePost
+      summary: Delete post (owner only)
+      responses:
+        '204': { description: ok }
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'


### PR DESCRIPTION
## Summary
- expose post update and delete routes in API
- document new endpoints in OpenAPI spec

## Testing
- `npx -y @redocly/cli lint docs/agent/api/openapi.yaml`
- `php artisan test` *(fails: Database file at path [testing] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689c66009a9c8327a00e51360e977efe