### PR TITLE
chore: configure larastan and workflow

### DIFF
--- a/.github/workflows/backend-laravel.yml
+++ b/.github/workflows/backend-laravel.yml
@@ -169,11 +169,11 @@ jobs:
 
       - name: Pint (lint)
         working-directory: backend-laravel
-        run: composer lint
+        run: ./vendor/bin/pint --test
 
       - name: Larastan (phpstan)
         working-directory: backend-laravel
-        run: composer analyse
+        run: ./vendor/bin/phpstan analyse --memory-limit=1G
 
       - name: Composer audit
         working-directory: backend-laravel

--- a/backend-laravel/phpstan.neon
+++ b/backend-laravel/phpstan.neon
@@ -1,0 +1,11 @@
+includes:
+  - phpstan-baseline.neon
+  - vendor/nunomaduro/larastan/extension.neon
+parameters:
+  paths:
+    - app
+    - tests
+  level: 5
+  ignoreErrors:
+    - '#Property .+ might not be defined#'
+  reportUnmatchedIgnoredErrors: false


### PR DESCRIPTION
## Summary
- add Larastan configuration
- run Pint and Larastan in CI via vendor binaries

## Testing
- `./vendor/bin/pint`
- `./vendor/bin/phpstan analyse --memory-limit=1G`
- `php artisan test --filter=AuthNegativeTest --stop-on-failure` *(fails: Database file at path [testing] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689c66012c8883279fb4f901d37914cc