### PR TITLE
docs: expand setup guides and env comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,16 @@
 
 👉 まずは `docs/agent/AGENT_OVERVIEW.md` と `docs/agent/TASKS_BOOTSTRAP.md` を読んでください。
 
-## Usage
+## Setup
 
 ### Backend
 ```bash
 cd backend-laravel
 cp .env.example .env
+composer install
 ./vendor/bin/sail up -d
 ./vendor/bin/sail artisan migrate:fresh --seed
-./vendor/bin/sail artisan test
 ```
-
-CI では Sail を使わず、ネイティブ PHP + Postgres サービスで高速にテストしています。
-Redis を無効化したい場合は `.env` で `CACHE_STORE=array` `SESSION_DRIVER=array` `QUEUE_CONNECTION=sync` に切り替えてください。
-CI は高速な `test` ジョブと、Redis サービスを起動して `--group=redis` のみ実行する `test-redis` ジョブに分かれます。`test-redis` を動かす際は、PHP に `redis` 拡張を入れて `REDIS_CLIENT=phpredis` を指定するか、`composer require predis/predis` した上で `REDIS_CLIENT=predis` を指定してください。
-
-Horizon を試す場合は `php artisan horizon` (Sailなら `./vendor/bin/sail artisan horizon`) を実行します。デフォルトではダッシュボードは無効になっています。ローカルで閲覧する場合は `HORIZON_ALLOW_DASHBOARD=true` を設定してください。
 
 ### Frontend
 ```bash
@@ -33,3 +27,36 @@ cd frontend
 npm install
 npm run dev
 ```
+
+## Testing
+
+### Backend
+```bash
+cd backend-laravel
+php artisan test
+```
+
+CI では Sail を使わず、ネイティブ PHP + Postgres サービスで高速にテストしています。
+Redis を無効化したい場合は `.env` で `CACHE_STORE=array` `SESSION_DRIVER=array` `QUEUE_CONNECTION=sync` に切り替えてください。
+CI は高速な `test` ジョブと、Redis サービスを起動して `--group=redis` のみ実行する `test-redis` ジョブに分かれます。`test-redis` を動かす際は、PHP に `redis` 拡張を入れて `REDIS_CLIENT=phpredis` を指定するか、`composer require predis/predis` した上で `REDIS_CLIENT=predis` を指定してください。
+
+### Frontend
+```bash
+cd frontend
+npm run lint
+```
+
+## Coding Standards
+
+- **Backend**: run Laravel Pint for code style checks.
+  ```bash
+  cd backend-laravel
+  ./vendor/bin/pint --test
+  ```
+- **Frontend**: run ESLint.
+  ```bash
+  cd frontend
+  npm run lint
+  ```
+
+Horizon を試す場合は `php artisan horizon` (Sailなら `./vendor/bin/sail artisan horizon`) を実行します。デフォルトではダッシュボードは無効になっています。ローカルで閲覧する場合は `HORIZON_ALLOW_DASHBOARD=true` を設定してください。

--- a/backend-laravel/.env.example
+++ b/backend-laravel/.env.example
@@ -1,10 +1,13 @@
 APP_NAME=Keijiban
 APP_ENV=local
 APP_KEY=
+# Set via `php artisan key:generate`
 APP_DEBUG=true
 APP_URL=http://localhost
+APP_TIMEZONE=UTC
 
 LOG_CHANNEL=stack
+LOG_LEVEL=debug
 
 DB_CONNECTION=pgsql
 DB_HOST=pgsql
@@ -27,7 +30,7 @@ REDIS_QUEUE_DB=2
 CACHE_STORE=redis          # Sail ローカルでは redis を既定ON
 SESSION_DRIVER=redis
 QUEUE_CONNECTION=sync      # 今はsync。将来redisに切替可
-SESSION_LIFETIME=120
+SESSION_LIFETIME=120       # minutes
 
 # Cache TTLs
 CACHE_TTL_THREADS=60
@@ -43,5 +46,5 @@ HORIZON_ALLOW_DASHBOARD=false
 # SESSION_DRIVER=array
 # QUEUE_CONNECTION=sync
 
-SANCTUM_STATEFUL_DOMAINS=localhost,127.0.0.1,localhost:3000
-FRONTEND_URL=http://localhost:3000
+SANCTUM_STATEFUL_DOMAINS=localhost,127.0.0.1,localhost:3000   # SPA auth domains
+FRONTEND_URL=http://localhost:3000                            # Next.js dev server

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,0 +1,16 @@
+# Developer Guide
+
+## Local Setup
+- Copy `.env.example` to `.env` in `backend-laravel/` and run `composer install`.
+- Start the backend with Laravel Sail: `./vendor/bin/sail up -d`.
+- For the frontend, install dependencies with `npm install` and run `npm run dev`.
+
+## Testing
+- Run backend tests with `php artisan test`.
+- Lint the frontend with `npm run lint`.
+
+## FAQ
+- **Tests fail because Redis is unavailable.**
+  Set `CACHE_STORE=array`, `SESSION_DRIVER=array`, and `QUEUE_CONNECTION=sync` in `.env` to disable Redis.
+- **How do I generate an application key?**
+  After copying `.env.example`, run `php artisan key:generate`.


### PR DESCRIPTION
## Summary
- document setup, testing workflow, and coding standards
- add developer guide with FAQ entries
- clarify .env.example with additional variables and notes

## Testing
- `php artisan test` *(fails: Database file at path [testing] does not exist)*
- `./vendor/bin/pint --test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c6602883083279de4a0b09ee0ea8d