### PR TITLE
Add login form validation and logout flow

### DIFF
--- a/frontend/app/components/Header.tsx
+++ b/frontend/app/components/Header.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { logout } from '../../lib/api';
+
+export default function Header() {
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+      router.push('/login');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <header style={{ padding: '1rem', borderBottom: '1px solid #ccc' }}>
+      <button onClick={handleLogout}>Logout</button>
+    </header>
+  );
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Header from "./components/Header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Header />
         {children}
       </body>
     </html>

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,27 +1,50 @@
 'use client';
 import { useState } from 'react';
+import { login } from '../../lib/api';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await fetch(process.env.NEXT_PUBLIC_CSRF_ENDPOINT!, { credentials: 'include' });
-    await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/login`, {
-      method: 'POST',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password }),
-    });
-    window.location.href = '/';
+    setError(null);
+    if (!email || !password) {
+      setError('Email and password are required');
+      return;
+    }
+    try {
+      setLoading(true);
+      await login(email, password);
+      window.location.href = '/';
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('Login failed');
+      }
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
     <form onSubmit={submit}>
-      <input value={email} onChange={e => setEmail(e.target.value)} placeholder="email" />
-      <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="password" />
-      <button type="submit">Login</button>
+      <input
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+        placeholder="email"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+        placeholder="password"
+      />
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <button type="submit" disabled={loading}>Login</button>
     </form>
   );
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -4,6 +4,21 @@ export async function api(path: string, init: RequestInit = {}) {
     headers: { 'Content-Type': 'application/json', ...(init.headers || {}) },
     ...init,
   });
-  if (!res.ok) throw new Error('API error');
+  if (!res.ok) {
+    const message = await res.text();
+    throw new Error(message || 'API error');
+  }
   return res.json();
+}
+
+export async function login(email: string, password: string) {
+  await fetch(process.env.NEXT_PUBLIC_CSRF_ENDPOINT!, { credentials: 'include' });
+  return api('/auth/login', {
+    method: 'POST',
+    body: JSON.stringify({ email, password }),
+  });
+}
+
+export async function logout() {
+  return api('/auth/logout', { method: 'POST' });
 }


### PR DESCRIPTION
## Summary
- add login form validation and error handling
- ensure API client persists session with cookie-based auth and provide login/logout helpers
- implement logout header component and include in layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c6603a250832786523adb07fc11a7