### PR TITLE
Add post form and reaction components

### DIFF
--- a/frontend/src/components/PostForm.tsx
+++ b/frontend/src/components/PostForm.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { api } from '@/lib/api';
+import type { Post } from './PostItem';
+
+type PostFormProps = {
+  threadId: number;
+  onCreated?: (post: Post) => void;
+};
+
+export default function PostForm({ threadId, onCreated }: PostFormProps) {
+  const [body, setBody] = useState('');
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await api(`/threads/${threadId}/posts`, {
+      method: 'POST',
+      body: JSON.stringify({ body }),
+    });
+    setBody('');
+    onCreated?.(res.data);
+  };
+
+  return (
+    <form onSubmit={submit}>
+      <textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder="Write a post..."
+      />
+      <button type="submit">Post</button>
+    </form>
+  );
+}

--- a/frontend/src/components/PostItem.tsx
+++ b/frontend/src/components/PostItem.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { api } from '@/lib/api';
+
+export type ReactionCounts = Record<string, number>;
+
+export type Post = {
+  id: number;
+  body: string;
+  reactions: ReactionCounts;
+  myReaction?: string | null;
+};
+
+type PostItemProps = {
+  post: Post;
+};
+
+export default function PostItem({ post }: PostItemProps) {
+  const [reactions, setReactions] = useState<ReactionCounts>(post.reactions);
+  const [myReaction, setMyReaction] = useState<string | null>(post.myReaction || null);
+
+  const react = async (type: string) => {
+    await api(`/posts/${post.id}/reactions`, {
+      method: 'POST',
+      body: JSON.stringify({ type }),
+    });
+
+    setReactions((prev) => {
+      const next = { ...prev };
+      if (myReaction === type) {
+        next[type] = (next[type] || 1) - 1;
+        setMyReaction(null);
+      } else {
+        if (myReaction) {
+          next[myReaction] = (next[myReaction] || 1) - 1;
+        }
+        next[type] = (next[type] || 0) + 1;
+        setMyReaction(type);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div>
+      <p>{post.body}</p>
+      <div>
+        <button onClick={() => react('like')}>
+          👍 {reactions['like'] || 0}
+        </button>
+        <button onClick={() => react('dislike')}>
+          👎 {reactions['dislike'] || 0}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add PostForm component to submit new posts
- add PostItem component with like/dislike reactions and local state updates

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c6608e0988327b6cd8d566a47b8aa