### PR TITLE
Align OpenAPI docs with API responses

### DIFF
--- a/docs/agent/api/openapi.yaml
+++ b/docs/agent/api/openapi.yaml
@@ -78,11 +78,51 @@ components:
       properties:
         code: { type: string }
         message: { type: string }
-        errors:
+        details:
           oneOf:
             - type: object
             - type: 'null'
       required: [code, message]
+    Envelope_User:
+      type: object
+      properties:
+        data: { $ref: '#/components/schemas/User' }
+        meta: { type: object }
+        error:
+          oneOf:
+            - $ref: '#/components/schemas/Error'
+            - type: 'null'
+      required: [data, meta, error]
+    Envelope_Thread:
+      type: object
+      properties:
+        data: { $ref: '#/components/schemas/Thread' }
+        meta: { type: object }
+        error:
+          oneOf:
+            - $ref: '#/components/schemas/Error'
+            - type: 'null'
+      required: [data, meta, error]
+    Envelope_Post:
+      type: object
+      properties:
+        data: { $ref: '#/components/schemas/Post' }
+        meta: { type: object }
+        error:
+          oneOf:
+            - $ref: '#/components/schemas/Error'
+            - type: 'null'
+      required: [data, meta, error]
+    Envelope_Reaction:
+      type: object
+      properties:
+        data: { $ref: '#/components/schemas/Reaction' }
+        meta: { type: object }
+        error:
+          oneOf:
+            - $ref: '#/components/schemas/Error'
+            - type: 'null'
+      required: [data, meta, error]
     Paginated_Thread:
       type: object
       properties:
@@ -91,7 +131,11 @@ components:
           items:
             $ref: '#/components/schemas/Thread'
         meta: { type: object }
-      required: [data, meta]
+        error:
+          oneOf:
+            - $ref: '#/components/schemas/Error'
+            - type: 'null'
+      required: [data, meta, error]
     Paginated_Post:
       type: object
       properties:
@@ -100,7 +144,11 @@ components:
           items:
             $ref: '#/components/schemas/Post'
         meta: { type: object }
-      required: [data, meta]
+        error:
+          oneOf:
+            - $ref: '#/components/schemas/Error'
+            - type: 'null'
+      required: [data, meta, error]
     Paginated_Reaction:
       type: object
       properties:
@@ -109,20 +157,35 @@ components:
           items:
             $ref: '#/components/schemas/Reaction'
         meta: { type: object }
-      required: [data, meta]
+        error:
+          oneOf:
+            - $ref: '#/components/schemas/Error'
+            - type: 'null'
+      required: [data, meta, error]
 paths:
   /auth/register:
     post:
       operationId: authRegister
       security: []
       summary: Register
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, email, password]
+              properties:
+                name: { type: string }
+                email: { type: string, format: email }
+                password: { type: string, minLength: 8 }
       responses:
         '201':
           description: created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/Envelope_User'
         '422':
           description: validation
           content:
@@ -134,10 +197,26 @@ paths:
       operationId: authLogin
       security: []
       summary: Login (sets cookie)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email, password]
+              properties:
+                email: { type: string, format: email }
+                password: { type: string }
       responses:
         '204': { description: ok }
         '401':
           description: unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: too many requests
           content:
             application/json:
               schema:
@@ -164,7 +243,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/Envelope_User'
         '401':
           description: unauthorized
           content:
@@ -176,6 +255,10 @@ paths:
       security: []
       operationId: listThreads
       summary: List threads
+      parameters:
+        - name: page
+          in: query
+          schema: { type: integer, minimum: 1, default: 1 }
       responses:
         '200':
           description: ok
@@ -183,22 +266,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Paginated_Thread'
-        '400':
-          description: bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
     post:
       operationId: createThread
       summary: Create thread
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [title]
+              properties:
+                title: { type: string, maxLength: 255 }
       responses:
         '201':
           description: created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Thread'
+                $ref: '#/components/schemas/Envelope_Thread'
         '401':
           description: unauthorized
           content:
@@ -227,7 +313,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Thread'
+                $ref: '#/components/schemas/Envelope_Thread'
         '404':
           description: not found
           content:
@@ -237,13 +323,22 @@ paths:
     patch:
       operationId: updateThread
       summary: Update (owner only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [title]
+              properties:
+                title: { type: string, maxLength: 255 }
       responses:
         '200':
           description: ok
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Thread'
+                $ref: '#/components/schemas/Envelope_Thread'
         '403':
           description: forbidden
           content:
@@ -289,6 +384,10 @@ paths:
       security: []
       operationId: listPosts
       summary: List posts
+      parameters:
+        - name: page
+          in: query
+          schema: { type: integer, minimum: 1, default: 1 }
       responses:
         '200':
           description: ok
@@ -305,13 +404,22 @@ paths:
     post:
       operationId: createPost
       summary: Create post
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [body]
+              properties:
+                body: { type: string }
       responses:
         '201':
           description: created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Post'
+                $ref: '#/components/schemas/Envelope_Post'
         '401':
           description: unauthorized
           content:
@@ -333,13 +441,22 @@ paths:
     put:
       operationId: updatePost
       summary: Update post (owner only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [body]
+              properties:
+                body: { type: string }
       responses:
         '200':
           description: ok
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Post'
+                $ref: '#/components/schemas/Envelope_Post'
         '403':
           description: forbidden
           content:
@@ -401,13 +518,22 @@ paths:
     post:
       operationId: createReaction
       summary: Create reaction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [type]
+              properties:
+                type: { type: string }
       responses:
         '201':
           description: created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Reaction'
+                $ref: '#/components/schemas/Envelope_Reaction'
         '401':
           description: unauthorized
           content:

--- a/frontend/lib/api-types.ts
+++ b/frontend/lib/api-types.ts
@@ -217,19 +217,42 @@ export interface components {
         Error: {
             code: string;
             message: string;
-            errors?: Record<string, never> | null;
+            details?: Record<string, never> | null;
+        };
+        Envelope_User: {
+            data: components["schemas"]["User"];
+            meta: Record<string, never>;
+            error: components["schemas"]["Error"] | null;
+        };
+        Envelope_Thread: {
+            data: components["schemas"]["Thread"];
+            meta: Record<string, never>;
+            error: components["schemas"]["Error"] | null;
+        };
+        Envelope_Post: {
+            data: components["schemas"]["Post"];
+            meta: Record<string, never>;
+            error: components["schemas"]["Error"] | null;
+        };
+        Envelope_Reaction: {
+            data: components["schemas"]["Reaction"];
+            meta: Record<string, never>;
+            error: components["schemas"]["Error"] | null;
         };
         Paginated_Thread: {
             data: components["schemas"]["Thread"][];
             meta: Record<string, never>;
+            error: components["schemas"]["Error"] | null;
         };
         Paginated_Post: {
             data: components["schemas"]["Post"][];
             meta: Record<string, never>;
+            error: components["schemas"]["Error"] | null;
         };
         Paginated_Reaction: {
             data: components["schemas"]["Reaction"][];
             meta: Record<string, never>;
+            error: components["schemas"]["Error"] | null;
         };
     };
     responses: never;
@@ -254,7 +277,6 @@ export interface operations {
                     /** Format: email */
                     email: string;
                     password: string;
-                    password_confirmation: string;
                 };
             };
         };
@@ -265,7 +287,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["User"];
+                    "application/json": components["schemas"]["Envelope_User"];
                 };
             };
             /** @description validation */
@@ -305,6 +327,15 @@ export interface operations {
             };
             /** @description unauthorized */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description too many requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -356,7 +387,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["User"];
+                    "application/json": components["schemas"]["Envelope_User"];
                 };
             };
             /** @description unauthorized */
@@ -372,7 +403,9 @@ export interface operations {
     };
     listThreads: {
         parameters: {
-            query?: never;
+            query?: {
+                page?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -386,15 +419,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Paginated_Thread"];
-                };
-            };
-            /** @description bad request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
                 };
             };
         };
@@ -420,7 +444,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Thread"];
+                    "application/json": components["schemas"]["Envelope_Thread"];
                 };
             };
             /** @description unauthorized */
@@ -460,7 +484,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Thread"];
+                    "application/json": components["schemas"]["Envelope_Thread"];
                 };
             };
             /** @description not found */
@@ -535,7 +559,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Thread"];
+                    "application/json": components["schemas"]["Envelope_Thread"];
                 };
             };
             /** @description unauthorized */
@@ -569,7 +593,9 @@ export interface operations {
     };
     listPosts: {
         parameters: {
-            query?: never;
+            query?: {
+                page?: number;
+            };
             header?: never;
             path: {
                 id: number;
@@ -621,7 +647,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Post"];
+                    "application/json": components["schemas"]["Envelope_Post"];
                 };
             };
             /** @description unauthorized */
@@ -667,7 +693,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Post"];
+                    "application/json": components["schemas"]["Envelope_Post"];
                 };
             };
             /** @description unauthorized */
@@ -791,7 +817,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Reaction"];
+                    "application/json": components["schemas"]["Envelope_Reaction"];
                 };
             };
             /** @description unauthorized */

--- a/frontend/src/components/PostForm.tsx
+++ b/frontend/src/components/PostForm.tsx
@@ -25,8 +25,12 @@ export default function PostForm({ threadId, onCreated }: PostFormProps) {
       console.error('Failed to create post:', error);
       return;
     }
+    if (!data) {
+      console.error('No data returned');
+      return;
+    }
     setBody('');
-    onCreated?.({ ...data, reactions: {}, myReaction: null });
+    onCreated?.({ ...data.data, reactions: {}, myReaction: null });
   };
 
   return (

--- a/frontend/src/pages/threads/[id].tsx
+++ b/frontend/src/pages/threads/[id].tsx
@@ -28,9 +28,9 @@ export default function ThreadPage() {
       api.GET('/user').catch(() => null),
     ])
       .then(([threadRes, postsRes, userRes]) => {
-        if (threadRes.data) setThread(threadRes.data);
+        if (threadRes.data?.data) setThread(threadRes.data.data);
         if (postsRes.data?.data) setPosts(postsRes.data.data);
-        if (userRes?.data) setCurrentUser(userRes.data);
+        if (userRes?.data?.data) setCurrentUser(userRes.data.data);
         setLoading(false);
       })
       .catch(() => {


### PR DESCRIPTION
## Summary
- document unified `{data, meta, error}` envelopes and switch error field to `details`
- add missing request bodies, rate-limit response, and pagination parameters
- regenerate frontend API types

## Testing
- `npx -y @redocly/cli lint docs/agent/api/openapi.yaml` (warning: Operation must have at least one `4XX` response.)
- `npx -y openapi-typescript@7.9.1 docs/agent/api/openapi.yaml -o frontend/lib/api-types.ts`
- `composer test` (fails: Database file at path [testing] does not exist)


------
https://chatgpt.com/codex/tasks/task_e_68a13f71d2ec83279f150dbe28df808d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized envelope responses (data, meta, error) across auth, user, threads, posts, and reactions.
  * Listing endpoints now support pagination via a page parameter.
  * Login now returns 429 Too Many Requests when rate-limited.

* **Documentation**
  * API docs updated to reflect envelope-wrapped responses and new request bodies for auth, threads, posts, and reactions.
  * Error payload renamed: errors → details.
  * Paginated responses now include an error field and require data, meta, and error.

* **Bug Fixes**
  * Frontend components updated to unwrap envelope responses and guard missing API data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->